### PR TITLE
allow adding a task containing "0"

### DIFF
--- a/src/components/List.jsx
+++ b/src/components/List.jsx
@@ -10,7 +10,7 @@ export default function List() {
     }
 
     const addTask = () => {
-        if(newTask != 0){
+        if(newTask.trim() !== ""){
             console.log("else")
             setList([...list, newTask])
             setNewTask('')


### PR DESCRIPTION
This is a small improvement.
It allows us to add tasks that contain "0". That wasn't possible in your previous version because you didn't use string comparison.
It also uses trim() to remove whitespace characters from the task string before comparing with an empty string. That prevents adding an task that contains only space "   ".